### PR TITLE
축제 이벤트 단일, 전체 조회API 

### DIFF
--- a/src/main/java/com/festival/domain/info/festivalEvent/controller/FestivalEventController.java
+++ b/src/main/java/com/festival/domain/info/festivalEvent/controller/FestivalEventController.java
@@ -3,16 +3,19 @@ package com.festival.domain.info.festivalEvent.controller;
 
 import com.festival.domain.info.festivalEvent.data.dto.FestivalEventReq;
 import com.festival.domain.info.festivalEvent.data.dto.FestivalEventRes;
+import com.festival.domain.info.festivalEvent.data.entity.FestivalEvent;
 import com.festival.domain.info.festivalEvent.service.FestivalEventService;
 import com.festival.domain.info.festivalPub.data.dto.request.PubRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.http.HttpResponse;
 import java.util.List;
 
 @RestController
@@ -26,5 +29,13 @@ public class FestivalEventController {
 
         FestivalEventRes festivalEventRes = festivalEventService.create(festivalEventReq, mainFile, subFiles);
 
+    }
+    @GetMapping("/festivalEvent/{id}")
+    public ResponseEntity<FestivalEventRes> findFestivalEvent(@PathVariable("id") Long festivalEventId){
+        return ResponseEntity.ok().body(festivalEventService.find(festivalEventId));
+    }
+    @GetMapping("/festivalEvent/list")
+    public ResponseEntity<Page<FestivalEventRes>> findFestivalEventList(@RequestParam("page") int offset, @RequestParam("state") Boolean state){
+        return ResponseEntity.ok().body(festivalEventService.list(1L, offset, state));
     }
 }

--- a/src/main/java/com/festival/domain/info/festivalEvent/data/dto/FestivalEventRes.java
+++ b/src/main/java/com/festival/domain/info/festivalEvent/data/dto/FestivalEventRes.java
@@ -1,4 +1,67 @@
 package com.festival.domain.info.festivalEvent.data.dto;
 
+import com.festival.domain.info.festivalEvent.data.entity.FestivalEvent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FestivalEventRes {
+
+    private Long festivalEventId;
+
+
+    private String title;
+
+    private String subTitle;
+
+    private String content;
+
+    private LocalDateTime createdDate;
+
+    private LocalDateTime modifiedDate;
+
+    private String filePath;
+
+    private List<String> subFilePath;
+
+    private int latitude;
+
+    private int longitude;
+
+    private Boolean festivalEventState;
+
+    @Builder
+    public FestivalEventRes(Long festivalEventId, String title, String subTitle, String content, LocalDateTime createdDate, LocalDateTime modifiedDate, String filePath, List<String> subFilePath, int latitude, int longitude, Boolean festivalEventState) {
+        this.festivalEventId = festivalEventId;
+        this.title = title;
+        this.subTitle = subTitle;
+        this.content = content;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+        this.filePath = filePath;
+        this.subFilePath = subFilePath;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.festivalEventState = festivalEventState;
+    }
+    public static FestivalEventRes of(FestivalEvent festivalEvent){
+        return FestivalEventRes.builder()
+                .festivalEventId(festivalEvent.getId())
+                .title(festivalEvent.getTitle())
+                .content(festivalEvent.getContent())
+                .subTitle(festivalEvent.getSubTitle())
+                .createdDate(festivalEvent.getCreatedDate())
+                .modifiedDate(festivalEvent.getModifiedDate())
+                .filePath(festivalEvent.getFestivalEventImage().getMainFilePath())
+                .subFilePath(festivalEvent.getFestivalEventImage().getSubFilePaths())
+                .latitude(festivalEvent.getLatitude())
+                .longitude(festivalEvent.getLongitude())
+                .festivalEventState(festivalEvent.getFestivalEventState())
+                .build();
+    }
 }

--- a/src/main/java/com/festival/domain/info/festivalEvent/data/entity/FestivalEvent.java
+++ b/src/main/java/com/festival/domain/info/festivalEvent/data/entity/FestivalEvent.java
@@ -4,6 +4,7 @@ package com.festival.domain.info.festivalEvent.data.entity;
 import com.festival.domain.admin.data.entity.Admin;
 import com.festival.domain.info.festivalEvent.data.dto.FestivalEventReq;
 import com.festival.domain.info.festivalPub.data.entity.file.PubImage;
+import com.festival.global.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +17,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FestivalEvent {
+public class FestivalEvent extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "festivalEvent_id")

--- a/src/main/java/com/festival/domain/info/festivalEvent/repository/FestivalEventRepository.java
+++ b/src/main/java/com/festival/domain/info/festivalEvent/repository/FestivalEventRepository.java
@@ -1,7 +1,12 @@
 package com.festival.domain.info.festivalEvent.repository;
 
 import com.festival.domain.info.festivalEvent.data.entity.FestivalEvent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FestivalEventRepository extends JpaRepository<FestivalEvent, Long> {
+    Page<FestivalEvent> findByAdminIdAndFestivalEventState(Long id, Boolean state, Pageable pageable);
 }

--- a/src/main/java/com/festival/domain/info/festivalEvent/service/FestivalEventService.java
+++ b/src/main/java/com/festival/domain/info/festivalEvent/service/FestivalEventService.java
@@ -8,15 +8,17 @@ import com.festival.domain.info.festivalEvent.data.entity.FestivalEvent;
 import com.festival.domain.info.festivalEvent.data.entity.FestivalEventImage;
 import com.festival.domain.info.festivalEvent.repository.FestivalEventImageRepository;
 import com.festival.domain.info.festivalEvent.repository.FestivalEventRepository;
-import com.festival.domain.info.festivalPub.data.dto.response.PubResponse;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -26,8 +28,7 @@ public class FestivalEventService {
     private final FestivalEventRepository festivalEventRepository;
     private final FestivalEventImageRepository festivalEventImageRepository;
     public FestivalEventRes create(FestivalEventReq festivalEventReq, MultipartFile mainFile, List<MultipartFile> subFiles) throws IOException {
-        Admin admin = new Admin();
-        adminRepository.save(admin);
+        Admin admin = adminRepository.findById(1L).orElse(null);
 
         FestivalEventImage festivalEventImage = FestivalEventImage.of(mainFile, subFiles);
         festivalEventImageRepository.save(festivalEventImage);
@@ -35,7 +36,24 @@ public class FestivalEventService {
         FestivalEvent festivalEvent = FestivalEvent.of(festivalEventReq, festivalEventImage, admin);
         festivalEventRepository.save(festivalEvent);
 
-        FestivalEventRes festivalEventRes = new FestivalEventRes();
-        return festivalEventRes;
+
+        return FestivalEventRes.of(festivalEvent);
+    }
+
+    public FestivalEventRes find(Long festivalEventId) {
+        FestivalEvent festivalEvent = festivalEventRepository.findById(festivalEventId).orElse(null);
+        return FestivalEventRes.of(festivalEvent);
+
+        //FestivalEventRes festivalEventRes = new FestivalEventRes();
+        //return festivalEventRes;
+    }
+    public Page<FestivalEventRes> list(long l, int offset, Boolean state) {
+
+        Pageable pageable = PageRequest.of(offset, 6);
+        Page<FestivalEvent> festivalEvents = festivalEventRepository.findByAdminIdAndFestivalEventState(1L, true, pageable);
+        return festivalEvents.map(FestivalEventRes::of);
+
+        //FestivalEventRes festivalEventRes = new FestivalEventRes();
+        //return festivalEventRes;
     }
 }

--- a/src/main/java/com/festival/initData/NotProd.java
+++ b/src/main/java/com/festival/initData/NotProd.java
@@ -1,0 +1,25 @@
+package com.festival.initData;
+
+import com.festival.domain.admin.data.entity.Admin;
+import com.festival.domain.admin.repository.AdminRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.Transactional;
+
+@Configuration
+public class NotProd {
+    @Bean
+    CommandLineRunner initData(
+            AdminRepository adminRepository
+    ){
+        return new CommandLineRunner() {
+            @Override
+            @Transactional
+            public void run(String... args) throws Exception {
+                adminRepository.save(new Admin());
+
+            }
+        };
+    }
+}


### PR DESCRIPTION
- 축제 이벤트 단일 조회 API를 작성합니다.
- 축제 이벤트 전체 조회 API를 작성합니다.
- Paging처리
- initData추가 어드민계정 생성