### PR TITLE
refactor: 연관관계 수정 (#53)

### DIFF
--- a/src/main/java/com/festival/domain/admin/data/entity/Admin.java
+++ b/src/main/java/com/festival/domain/admin/data/entity/Admin.java
@@ -23,8 +23,4 @@ public class Admin {
 
     @OneToMany(mappedBy = "admin")
     private List<FoodTruck> foodTruckList = new ArrayList<>();
-
-    public void addPub(Pub pub) {
-        this.pubs.add(pub);
-    }
 }

--- a/src/main/java/com/festival/domain/fleaMarket/data/entity/FleaMarket.java
+++ b/src/main/java/com/festival/domain/fleaMarket/data/entity/FleaMarket.java
@@ -25,8 +25,7 @@ public class FleaMarket extends BaseTimeEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "market_image_id")
+    @OneToOne(mappedBy = "fleaMarket", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private FleaMarketImage marketImage;
 
     @Column(name = "latitude", nullable = false) // 위도

--- a/src/main/java/com/festival/domain/fleaMarket/data/entity/FleaMarketImage.java
+++ b/src/main/java/com/festival/domain/fleaMarket/data/entity/FleaMarketImage.java
@@ -25,7 +25,8 @@ public class FleaMarketImage {
     @Column(name = "file_name")
     private List<String> subFileNames = new ArrayList<>();
 
-    @OneToOne(mappedBy = "marketImage", fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_image_id")
     private FleaMarket fleaMarket;
 
     public FleaMarketImage(String mainFilePath, FleaMarket fleaMarket) {

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/file/PubImage.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/file/PubImage.java
@@ -26,7 +26,7 @@ public class PubImage {
     @Column(name = "file_name")
     private List<String> subFileNames = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pub_id")
     private Pub pub;
 

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/file/PubImage.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/file/PubImage.java
@@ -26,7 +26,8 @@ public class PubImage {
     @Column(name = "file_name")
     private List<String> subFileNames = new ArrayList<>();
 
-    @OneToOne(mappedBy = "pubImage", fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "pub_id")
     private Pub pub;
 
     public PubImage(String mainFilePath, Pub pub) {

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
@@ -43,24 +43,25 @@ public class Pub extends BaseTimeEntity {
     @JoinColumn(name = "admin_id", nullable = false)
     private Admin admin;
 
-    public Pub(String title, String subTitle, String content, int latitude, int longitude, Boolean pubState, Admin admin) {
+    public Pub(String title, String subTitle, String content, int latitude, int longitude, Boolean pubState) {
         this.title = title;
         this.subTitle = subTitle;
         this.content = content;
         this.latitude = latitude;
         this.longitude = longitude;
         this.pubState = pubState;
-        this.admin = admin;
-        admin.getPubs().add(this);
     }
 
-    public Pub(PubRequest pubRequest, Admin admin) {
+    public Pub(PubRequest pubRequest) {
         this.title = pubRequest.getTitle();
         this.subTitle = pubRequest.getSubTitle();
         this.content = pubRequest.getContent();
         this.latitude = pubRequest.getLatitude();
         this.longitude = pubRequest.getLongitude();
         this.pubState = pubRequest.getPubState();
+    }
+
+    public void connectAdmin(Admin admin) {
         this.admin = admin;
         admin.getPubs().add(this);
     }

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
@@ -51,6 +51,7 @@ public class Pub extends BaseTimeEntity {
         this.longitude = longitude;
         this.pubState = pubState;
         this.admin = admin;
+        admin.addPub(this);
     }
 
     public Pub(PubRequest pubRequest, Admin admin) {
@@ -61,6 +62,7 @@ public class Pub extends BaseTimeEntity {
         this.longitude = pubRequest.getLongitude();
         this.pubState = pubRequest.getPubState();
         this.admin = admin;
+        admin.addPub(this);
     }
 
     public void connectPubImage(PubImage pubImage) {

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
@@ -27,7 +27,7 @@ public class Pub extends BaseTimeEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @OneToOne(mappedBy = "pub", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "pub", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private PubImage pubImage;
 
     @Column(name = "latitude", nullable = false) // 위도

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
@@ -27,8 +27,7 @@ public class Pub extends BaseTimeEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "pub_image_id")
+    @OneToOne(mappedBy = "pub", fetch = FetchType.LAZY)
     private PubImage pubImage;
 
     @Column(name = "latitude", nullable = false) // 위도

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
@@ -51,7 +51,7 @@ public class Pub extends BaseTimeEntity {
         this.longitude = longitude;
         this.pubState = pubState;
         this.admin = admin;
-        admin.addPub(this);
+        admin.getPubs().add(this);
     }
 
     public Pub(PubRequest pubRequest, Admin admin) {
@@ -62,7 +62,7 @@ public class Pub extends BaseTimeEntity {
         this.longitude = pubRequest.getLongitude();
         this.pubState = pubRequest.getPubState();
         this.admin = admin;
-        admin.addPub(this);
+        admin.getPubs().add(this);
     }
 
     public void connectPubImage(PubImage pubImage) {

--- a/src/main/java/com/festival/domain/info/festivalPub/service/PubService.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/service/PubService.java
@@ -51,7 +51,6 @@ public class PubService {
 
         Pub pub = new Pub(pubRequest, admin);
         pubRepository.save(pub);
-        admin.addPub(pub);
 
         String mainFileName = utils.createStoreFileName(mainFile.getOriginalFilename());
         mainFile.transferTo(new File(filePath + mainFileName));

--- a/src/main/java/com/festival/domain/info/festivalPub/service/PubService.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/service/PubService.java
@@ -51,6 +51,7 @@ public class PubService {
 
         Pub pub = new Pub(pubRequest, admin);
         pubRepository.save(pub);
+        admin.addPub(pub);
 
         String mainFileName = utils.createStoreFileName(mainFile.getOriginalFilename());
         mainFile.transferTo(new File(filePath + mainFileName));

--- a/src/main/java/com/festival/domain/info/festivalPub/service/PubService.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/service/PubService.java
@@ -49,15 +49,16 @@ public class PubService {
 
         Admin admin = adminRepository.findById(adminId).orElseThrow(() -> new AdminException("관리자를 찾을 수 없습니다."));
 
-        Pub pub = new Pub(pubRequest, admin);
+        Pub pub = new Pub(pubRequest);
         pubRepository.save(pub);
 
-        String mainFileName = utils.createStoreFileName(mainFile.getOriginalFilename());
-        mainFile.transferTo(new File(filePath + mainFileName));
+        String mainFileName = saveMainFile(mainFile);
         PubImage pubImage = new PubImage(mainFileName, pub);
         pubImageRepository.save(pubImage);
 
         saveSubFiles(subFiles, pubImage);
+
+        pub.connectAdmin(admin);
         pub.connectPubImage(pubImage);
 
         return PubResponse.of(pub, filePath);
@@ -135,6 +136,12 @@ public class PubService {
 
         Page<Pub> findPubs = pubRepository.findByIdPubsWithState(cond, pageable);
         return findPubs.map(pub -> PubResponse.of(pub, filePath));
+    }
+
+    private String saveMainFile(MultipartFile mainFile) throws IOException {
+        String mainFileName = utils.createStoreFileName(mainFile.getOriginalFilename());
+        mainFile.transferTo(new File(filePath + mainFileName));
+        return mainFileName;
     }
 
     private void saveSubFiles(List<MultipartFile> subFiles, PubImage pubImage) throws IOException {


### PR DESCRIPTION
# 개발 내용
- 현재 주점 엔티티에는 주인 엔티티가 아님에도 불구하고 이미지 엔티티의 외래키를 매핑하고 있었던 겁니다. 주인 엔티티가 아닐 경우 외래키를 가지고 있어선 안됩니다.
- 따라서 PubImage의 pub 객체를 주인으로 정하여 PubImage에 외래키를 저장하게 하고, 주점 엔티티에서 PubImage에 저장되던 pub에 매핑되도록 수정하였습니다.