### PR TITLE
refactor: 연관관계 설정 단방향으로 변경 (#60)

### DIFF
--- a/src/main/java/com/festival/domain/admin/data/entity/Admin.java
+++ b/src/main/java/com/festival/domain/admin/data/entity/Admin.java
@@ -17,10 +17,4 @@ public class Admin {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
-
-    @OneToMany(mappedBy = "admin")
-    private List<Pub> pubs = new ArrayList<>();
-
-    @OneToMany(mappedBy = "admin")
-    private List<FoodTruck> foodTruckList = new ArrayList<>();
 }

--- a/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
+++ b/src/main/java/com/festival/domain/info/festivalPub/data/entity/pub/Pub.java
@@ -63,7 +63,6 @@ public class Pub extends BaseTimeEntity {
 
     public void connectAdmin(Admin admin) {
         this.admin = admin;
-        admin.getPubs().add(this);
     }
 
     public void connectPubImage(PubImage pubImage) {


### PR DESCRIPTION
# 개발 내용
- 현재 adminId로 getPubs를 찾는 일이 없고, querydsl로 pub의 쿼리를 생성하여 adminId를 찾아서 Page를 반환하는 작업을 하고 있습니다.
- 이 경우 Pub에 admin이 단방향으로 이미 연관관계가 설정되어 있기 때문에, 굳이 사용하는 로직이 있지 않다면 단방향으로만 구성하여도 괜찮다고 합니다. 따라서 아직 Admin 엔티티에 pubs 변수를 사용하는 일이 없기 때문에 단방향으로만 연관관계를 설정해보고 테스트 해보려 합니다.